### PR TITLE
Move api calls into a single directory

### DIFF
--- a/src/api/dose-rate.js
+++ b/src/api/dose-rate.js
@@ -1,0 +1,19 @@
+import http from "@/utils/http"
+
+export default {
+    /**
+     * Get metadata file.
+     */
+    async getMetadata () {
+        const response = await http.get("data/dose_rates/metadata.json")
+        return response.body.available_data
+    },
+    /**
+     * Get a time series file.
+     * @param {String} url
+     */
+    async getTimeSeries (url) {
+        const response = await http.get(url)
+        return response.data.data
+    }
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,5 @@
+import doseRate from "./dose-rate"
+
+export default {
+    doseRate: doseRate
+}

--- a/src/components/FeaturePopupGraph.vue
+++ b/src/components/FeaturePopupGraph.vue
@@ -4,7 +4,7 @@
 
 <script>
 import dateUtils from "@/utils/date"
-import http from "@/utils/http"
+import api from "@/api"
 
 import Plotly from "plotly.js/lib/core"
 import localeFI from "plotly.js/lib/locales/fi"
@@ -139,12 +139,12 @@ export default {
                 that.draw()
             })
         },
-        loadDataset (dataset) {
-            var that = this
-            return http.get(dataset.filePath).then(function (response) {
-                dataset["data"] = response.data.data
-                that.addDataset(dataset)
-            }).catch(() => {})
+        async loadDataset (dataset) {
+            try {
+                dataset["data"] = await api.doseRate.getTimeSeries(dataset.filePath)
+                this.addDataset(dataset)
+            }
+            catch {() => {}}
         },
         loadDatasets (datasets) {
             var that = this

--- a/src/store/modules/datetime-module.js
+++ b/src/store/modules/datetime-module.js
@@ -1,4 +1,4 @@
-import http from "../../utils/http"
+import api from "@/api"
 
 export default {
     state: {
@@ -90,10 +90,9 @@ export default {
             // Update available data every 10 minutes.
             setInterval(() => { dispatch("updateAvailableDatetimes") }, 600000)
         },
-        updateAvailableDatetimes ({ commit }) {
-            return http.get("data/dose_rates/metadata.json").then(function (response) {
-                commit("setValidDatetimes", response.body.available_data)
-            })
+        async updateAvailableDatetimes ({ commit }) {
+            const availableData = await api.doseRate.getMetadata()
+            commit("setValidDatetimes", availableData)
         },
         selectMostRecentDate ({ state, dispatch }) {
             if (state.validDatetimes.length == 0) {

--- a/src/utils/http.js
+++ b/src/utils/http.js
@@ -1,8 +1,8 @@
 import Vue from "vue"
 
 export default {
-    get (url) {
-        return Vue.http.get(url)
+    async get (url) {
+        return await Vue.http.get(url)
             .then((response) => Promise.resolve(response))
             .catch((error) => Promise.reject(error))
     }


### PR DESCRIPTION
API calls were previously scattered in the code base. This change names them and moves them into a single location.