### PR TITLE
Add app version number to settings page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "opendata",
+  "version": "1.0.0",
   "description": "An independent web application for viewing STUK's open data",
   "author": "Radiation and Nuclear Safety Authority (STUK)",
   "license": "MIT",

--- a/src/components/SettingsWidget.vue
+++ b/src/components/SettingsWidget.vue
@@ -13,7 +13,7 @@
         />
         <div
             v-show="isEnabled"
-            class="settings-panel container p-5"
+            class="settings-panel container pt-5 pl-5 pr-5 pb-2"
         >
             <div class="row">
                 <div class="col">
@@ -83,6 +83,9 @@
                     </b-button>
                 </div>
             </div>
+            <div class="row justify-content-center mt-3 app-version">
+                <p>{{ appVersion }}</p>
+            </div>
         </div>
     </div>
 </template>
@@ -134,6 +137,13 @@ export default {
             set (timeFormat) {
                 this.$store.commit("setTimeFormat", timeFormat)
             }
+        },
+        appVersion () {
+            let version = "v" + process.env.APP_VERSION
+            if (process.env.NODE_ENV == "development") {
+                version += " (dev)"
+            }
+            return version
         }
     },
     methods: {
@@ -220,6 +230,10 @@ input[type=number]::-webkit-outer-spin-button {
 
 input[type=number] {
     -moz-appearance:textfield;
+}
+
+.app-version {
+    color: lightgray;
 }
 
 @media only screen and (min-width: 768px) {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,8 +1,21 @@
+const webpack = require("webpack")
+const fs = require("fs")
+
+const packageJSON = fs.readFileSync("./package.json")
+const version = JSON.parse(packageJSON).version || 0
+
 module.exports = {
     publicPath: "./",
     productionSourceMap: false,
     configureWebpack: {
-        devtool: "source-map"
+        devtool: "source-map",
+        plugins: [
+            new webpack.DefinePlugin({
+                "process.env": {
+                    APP_VERSION: "'" + version + "'"
+                }
+            })
+        ]
     },
     pluginOptions: {
         i18n: {


### PR DESCRIPTION
Changes
* Add a version number to the package.json file.
* Add the version number as an environment variable accessible from source code.
* Display the version number under the close button in the settings page. For example, in production mode "v1.0.0" is displayed. In development mode "(dev)" is appended to the version number, for example, "v1.0.0 (dev)".