### PR TITLE
Lmalmber/layer refactor

### DIFF
--- a/src/api/dose-rate.js
+++ b/src/api/dose-rate.js
@@ -24,7 +24,7 @@ export default {
     },
     /**
      * Get a dose rate dataset file.
-     * @param {String} filePath
+     * @param {String} datasetFilePath
      */
     async getDataset (datasetFilePath) {
         let response = await http.get(datasetFilePath)

--- a/src/api/dose-rate.js
+++ b/src/api/dose-rate.js
@@ -23,6 +23,14 @@ export default {
         return availableDatasets
     },
     /**
+     * Get a dose rate dataset file.
+     * @param {String} filePath
+     */
+    async getDataset (datasetFilePath) {
+        let response = await http.get(datasetFilePath)
+        return response.data
+    },
+    /**
      * Get a time series file for a given site and date.
      * @param {String} siteId
      * @param {Date} date

--- a/src/components/TheMap.vue
+++ b/src/components/TheMap.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script>
-import DoseRateLayer from "./DoseRateLayer"
+import DoseRateLayer from "./layers/DoseRateLayer"
 import MapLegend from "@/components/map-legend/MapLegend"
 import FeaturePopover from "@/components/feature-popover/FeaturePopover"
 import FeaturePopup from "@/components/feature-popup/FeaturePopup"
@@ -89,7 +89,6 @@ export default {
         this.map.addOverlay(this.$refs.featurePopover.overlay)
         this.map.addOverlay(this.$refs.featurePopup.overlay)
         this.map.addLayer(this.$refs.doseRateLayer.vectorLayer)
-        this.map.addLayer(this.$refs.doseRateLayer.bufferLayer)
     },
     methods: {
         onMapInteraction (evt) {

--- a/src/components/layers/DoseRateLayer.vue
+++ b/src/components/layers/DoseRateLayer.vue
@@ -21,14 +21,13 @@ export default {
         return {
             vectorLayer: new VectorLayer({
                 source: new VectorSource({
-                    format: this.featureFormat
+                    format: new GeoJSON({
+                        defaultDataProjection: "EPSG:4326"
+                    })
                 }),
                 style: this.styleFeature,
                 renderOrder: this.orderFeatures,
                 renderMode: "image"
-            }),
-            featureFormat: new GeoJSON({
-                defaultDataProjection: "EPSG:4326"
             })
         }
     },

--- a/src/components/layers/DoseRateLayer.vue
+++ b/src/components/layers/DoseRateLayer.vue
@@ -9,7 +9,6 @@ import FillStyle from "ol/style/Fill"
 import Style from "ol/style/Style"
 import VectorLayer from "ol/layer/Vector"
 import VectorSource from "ol/source/Vector"
-
 import Feature from "ol/Feature"
 import Point from "ol/geom/Point"
 import { transform } from "ol/proj"

--- a/src/components/layers/DoseRateLayer.vue
+++ b/src/components/layers/DoseRateLayer.vue
@@ -46,8 +46,8 @@ export default {
     },
     watch: {
         datasetFilePath: async function () {
-            let dataset = await api.doseRate.getDataset(this.datasetFilePath)
-            let features = dataset.features.map(feature => {
+            const dataset = await api.doseRate.getDataset(this.datasetFilePath)
+            const features = dataset.features.map(feature => {
                 return new Feature({
                     geometry: new Point(transform(feature.geometry.coordinates, "EPSG:4326", "EPSG:3857")),
                     id: feature.properties.id,


### PR DESCRIPTION
Simplify implementation of dose rate layer. The dataset file is now loaded directly with an API call. Map features are constructed from the dataset file manually and added to the visible layer. Previously the dataset file was loaded into a buffer layer that was then swapped with the visible layer. This was done because changing the source of the visible layer to load a new dataset caused the layer to be momentarily empty as the new file was loaded. This caused a flicker in the user interface as map features disappeared and reappeared. This does not happen with the new method because when the layer is cleared of old features the new features are already available and are added immediately.